### PR TITLE
📌 pin moment to 2.18.1 bc. moment#4228

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@essential-projects/timing_contracts": "^0.1.0",
     "addict-ioc": "^2.2.8",
     "debug": "^2.6.1",
-    "moment": "^2.18.1",
+    "moment": "2.18.1",
     "node-schedule": "^1.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Moment 2.19.0 doesn't play nice with webpack, so we pin it to 2.18.1. See https://github.com/moment/moment/issues/4228