### PR TITLE
♻️ Refactor cronjob handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,16 @@
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
   "author": "5Minds IT-Solutions GmbH & Co. KG",
-  "contributors": [
+  "maintainers": [
+    "Alexander Kasten <alexander.kasten@5minds.de>",
     "Christian Werner <christian.werner@5minds.de>",
+    "René Föhring <rene.foehring@5minds.de>",
+    "Steffen Knaup <steffen.knaup@5minds.de>"
+  ],
+  "contributors": [
+    "Christoph Gnip <christoph.gnip@5minds.de>",
+    "Paul Heidenreich <paul.heidenreich@5minds.de>",
+    "Heiko Mathes <heiko.mathes@5minds.de>",
     "Sebastian Meier <sebastian.meier@5minds.de>"
   ],
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "@essential-projects/event_aggregator_contracts": "^4.1.0",
-    "@essential-projects/timing_contracts": "^4.1.0",
+    "@essential-projects/timing_contracts": "feature~fix_cycle_timer_rule_parameter",
     "moment": "~2.24.0",
     "node-schedule": "~1.3.0",
     "node-uuid": "~1.4.8"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "4.2.0",
+  "version": "5.0.0",
   "description": "components for timing",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
     "Sebastian Meier <sebastian.meier@5minds.de>"
   ],
   "dependencies": {
+    "@essential-projects/errors_ts": "^1.5.0",
     "@essential-projects/event_aggregator_contracts": "^4.1.0",
     "@essential-projects/timing_contracts": "feature~fix_cycle_timer_rule_parameter",
     "cron-parser": "^2.12.0",
+    "loggerhythm": "^3.0.4",
     "moment": "~2.24.0",
     "node-schedule": "~1.3.0",
     "node-uuid": "~1.4.8"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@essential-projects/event_aggregator_contracts": "^4.1.0",
     "@essential-projects/timing_contracts": "feature~fix_cycle_timer_rule_parameter",
+    "cron-parser": "^2.12.0",
     "moment": "~2.24.0",
     "node-schedule": "~1.3.0",
     "node-uuid": "~1.4.8"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
     "@essential-projects/event_aggregator_contracts": "^4.1.0",
-    "@essential-projects/timing_contracts": "feature~fix_cycle_timer_rule_parameter",
+    "@essential-projects/timing_contracts": "^5.0.0",
     "cron-parser": "^2.12.0",
     "loggerhythm": "^3.0.4",
     "moment": "~2.24.0",

--- a/src/timer_service.ts
+++ b/src/timer_service.ts
@@ -1,6 +1,6 @@
 import {IEventAggregator} from '@essential-projects/event_aggregator_contracts';
 import {
-  ITimerService, Timer, TimerRule, TimerType,
+  ITimerService, Timer, TimerType,
 } from '@essential-projects/timing_contracts';
 
 import * as moment from 'moment';
@@ -42,7 +42,7 @@ export class TimerService implements ITimerService {
     return this.createTimer(TimerType.once, date, undefined, eventName);
   }
 
-  public periodic(rule: TimerRule, eventName: string): string {
+  public periodic(rule: string, eventName: string): string {
 
     if (!rule) {
       throw new Error('Must provide a rule for a periodic timer!');
@@ -54,7 +54,7 @@ export class TimerService implements ITimerService {
   private createTimer(
     timerType: TimerType,
     timerDate: moment.Moment,
-    timerRule: TimerRule,
+    timerRule: string,
     eventName: string,
   ): string {
 

--- a/src/timer_service.ts
+++ b/src/timer_service.ts
@@ -1,11 +1,11 @@
+import * as moment from 'moment';
+import * as schedule from 'node-schedule';
+import * as uuid from 'node-uuid';
+
 import {IEventAggregator} from '@essential-projects/event_aggregator_contracts';
 import {
   ITimerService, Timer, TimerType,
 } from '@essential-projects/timing_contracts';
-
-import * as moment from 'moment';
-import * as schedule from 'node-schedule';
-import * as uuid from 'node-uuid';
 
 interface IJobsCache {
   [timerId: string]: schedule.Job;

--- a/src/timer_service.ts
+++ b/src/timer_service.ts
@@ -36,7 +36,7 @@ export class TimerService implements ITimerService {
     }
   }
 
-  public once(date: moment.Moment, eventName: string): string {
+  public oneShot(date: moment.Moment, eventName: string): string {
 
     if (!date) {
       throw new Error('Must provide an expiration date for a one-shot timer!');
@@ -45,7 +45,7 @@ export class TimerService implements ITimerService {
     return this.createTimer(TimerType.oneShot, date, eventName);
   }
 
-  public periodic(crontab: string, eventName: string): string {
+  public cronjob(crontab: string, eventName: string): string {
 
     if (!crontab) {
       throw new Error('Must provide a crontab for a periodic timer!');

--- a/src/timer_service.ts
+++ b/src/timer_service.ts
@@ -1,3 +1,4 @@
+import * as cronparser from 'cron-parser';
 import * as moment from 'moment';
 import * as schedule from 'node-schedule';
 import * as uuid from 'node-uuid';
@@ -95,6 +96,8 @@ export class TimerService implements ITimerService {
       const timerHasAlreadyElapsed = timer.lastElapsed !== undefined;
 
       isValidTimer = timerHasAlreadyElapsed || expirationIsFutureDate;
+    } else {
+      cronparser.parseExpression(timer.rule);
     }
 
     return isValidTimer;

--- a/src/timer_service.ts
+++ b/src/timer_service.ts
@@ -47,13 +47,13 @@ export class TimerService implements ITimerService {
     return this.createTimer(TimerType.once, date, undefined, eventName);
   }
 
-  public periodic(rule: string, eventName: string): string {
+  public periodic(crontab: string, eventName: string): string {
 
-    if (!rule) {
-      throw new Error('Must provide a rule for a periodic timer!');
+    if (!crontab) {
+      throw new Error('Must provide a crontab for a periodic timer!');
     }
 
-    return this.createTimer(TimerType.periodic, undefined, rule, eventName);
+    return this.createTimer(TimerType.periodic, undefined, crontab, eventName);
   }
 
   private createTimer(


### PR DESCRIPTION
## Changes

Pretty much every change here is breaking.

1. Rename `ITimerService` functions
    - `once` is renamed `oneShot`
    - `periodic` is renamed to `cronjob`
2. Accept string-parameters for `cronjob` timers
3. Add `cron-parser` to dependencies
4. Add crontab validation to the service
5. Remove use of the `TimerRule` type
6. Node-Schedule will now receive the crontab strings, instead of the `TimerRule` type parameter
7. Add contributor and maintainer info

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/118

PR: #13

## How to test the changes

- Pass some crontab strings to the TimerService
- Valid crontabs will cause a cronjob to be created by node-schedule
- Invalid crontabs will cause an error, prior to any jobs being created
